### PR TITLE
Remove superfluous app.d entry point

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -8,10 +8,6 @@
   "license": "Apache 2.0",
   "configurations": [
     {
-      "name": "test",
-      "targetType": "executable"
-    },
-    {
       "name": "static",
       "targetType": "staticLibrary"
     },

--- a/source/app.d
+++ b/source/app.d
@@ -1,7 +1,0 @@
-module app;
-
-import std.stdio;
-
-void main() {
-    writeln("Tests passed.");
-}


### PR DESCRIPTION
`dub test` generates one automatically. And this makes sure the dummy module isn't part of the generated static/shared libraries.